### PR TITLE
Add SvecPSD cone support

### DIFF
--- a/gcsopt/programs.py
+++ b/gcsopt/programs.py
@@ -3,6 +3,11 @@ import cvxpy as cp
 from numbers import Number
 from gcsopt.safe_variable import safe_variable
 
+try:
+    from cvxpy.constraints.psd import SvecPSD
+except ImportError:
+    SvecPSD = None
+
 class ConicProgram:
 
     def __init__(self, size, id_to_range=None, binary_variable=None):
@@ -85,7 +90,12 @@ class ConicProgram:
             n = round(z.size ** .5)
             z_mat = cp.reshape(z, (n, n), order='F')
             return K(z_mat)
-        
+
+        # Scaled vectorized semidefinite constraint.
+        elif SvecPSD is not None and K == SvecPSD:
+            n = round((-1 + (1 + 8 * z.size) ** .5) / 2)
+            return K(z, n)
+
         # Exponential cone constraint.
         elif K == cp.ExpCone:
             z_mat = z.reshape((3, -1), order='C')

--- a/gcsopt/programs.py
+++ b/gcsopt/programs.py
@@ -94,7 +94,15 @@ class ConicProgram:
         # Scaled vectorized semidefinite constraint.
         elif SvecPSD is not None and K == SvecPSD:
             n = round((-1 + (1 + 8 * z.size) ** .5) / 2)
-            return K(z, n)
+            z_mat = [[None for _ in range(n)] for _ in range(n)]
+            idx = 0
+            for i in range(n):
+                for j in range(i, n):
+                    value = z[idx] if i == j else z[idx] / np.sqrt(2)
+                    z_mat[i][j] = value
+                    z_mat[j][i] = value
+                    idx += 1
+            return cp.PSD(cp.bmat(z_mat))
 
         # Exponential cone constraint.
         elif K == cp.ExpCone:

--- a/tests/test_programs.py
+++ b/tests/test_programs.py
@@ -1,7 +1,7 @@
 import unittest
 import numpy as np
 import cvxpy as cp
-from gcsopt.programs import ConicProgram, ConvexProgram
+from gcsopt.programs import ConicProgram, ConvexProgram, SvecPSD
 
 class TestConicProgram(unittest.TestCase):
 
@@ -68,6 +68,29 @@ class TestConicProgram(unittest.TestCase):
         b = np.array([0] * 11 + [-1])
         K = [(cp.constraints.PSD, 9), (cp.constraints.NonNeg, 3)]
         self.sdp.add_constraints(A, b, K)
+
+        # Svec semidefinite program equal to the previous SDP. The svec of a
+        # symmetric 3x3 matrix extracts the lower triangle in column-major
+        # order with off-diagonals scaled by sqrt(2):
+        #   svec(M) = [M00, sqrt(2)*M10, sqrt(2)*M20, M11, sqrt(2)*M21, M22]
+        if SvecPSD is not None:
+            s2 = np.sqrt(2)
+            self.svec_sdp = ConicProgram(3)
+            self.svec_sdp.add_cost(c, d)
+            A = np.array([
+                [1, 0, 0],     # svec entry 0: M00 = x1
+                [0, s2, 0],    # svec entry 1: sqrt(2)*M10 = sqrt(2)*x2
+                [0, 0, s2],    # svec entry 2: sqrt(2)*M20 = sqrt(2)*x3
+                [1, 0, 0],     # svec entry 3: M11 = x1
+                [0, 0, 0],     # svec entry 4: sqrt(2)*M21 = 0
+                [1, 0, 0],     # svec entry 5: M22 = x1
+                [1, -1, 0],
+                [0, 1, -1],
+                [0, 0, 1],
+            ])
+            b = np.array([0] * 8 + [-1])
+            K = [(SvecPSD, 6), (cp.constraints.NonNeg, 3)]
+            self.svec_sdp.add_constraints(A, b, K)
 
     def test_add_cost(self):
 
@@ -166,6 +189,13 @@ class TestConicProgram(unittest.TestCase):
         cost = self.sdp.solve()
         self.assertAlmostEqual(cost, 4, places=4)
         np.testing.assert_array_almost_equal(self.sdp.x.value, [np.sqrt(2), 1, 1], decimal=4)
+
+        # svec semidefinite program
+        if SvecPSD is not None:
+            cost = self.svec_sdp.solve()
+            self.assertAlmostEqual(cost, 4, places=4)
+            np.testing.assert_array_almost_equal(
+                self.svec_sdp.x.value, [np.sqrt(2), 1, 1], decimal=4)
 
         # Program with no variables.
         prog = ConicProgram(0)

--- a/tests/test_programs.py
+++ b/tests/test_programs.py
@@ -197,6 +197,15 @@ class TestConicProgram(unittest.TestCase):
             np.testing.assert_array_almost_equal(
                 self.svec_sdp.x.value, [np.sqrt(2), 1, 1], decimal=4)
 
+            prog = ConicProgram(6)
+            prog.add_cost(np.array([1, 0, 0, 1, 0, 1]), 0)
+            A = np.vstack((np.eye(6), np.array([[1, 0, 0, 0, 0, 0]])))
+            b = np.array([0] * 6 + [-1])
+            K = [(SvecPSD, 6), (cp.constraints.NonNeg, 1)]
+            prog.add_constraints(A, b, K)
+            cost = prog.solve()
+            self.assertAlmostEqual(cost, 1, places=4)
+
         # Program with no variables.
         prog = ConicProgram(0)
         prog.add_cost(np.zeros(0), 1.33)


### PR DESCRIPTION
## Summary
- Add support for `SvecPSD` (scaled vectorized PSD) cone constraints, which newer CVXPY versions produce when reducing PSD constraints
- Gracefully falls back when running on older CVXPY versions that don't have `SvecPSD`
- Add corresponding conic program test case

## Test plan
- [x] All 20 existing tests pass on CVXPY 1.8.1 (SvecPSD tests gracefully skipped)
- [x] SvecPSD conic solve verified on dev CVXPY 1.9.0 (produces correct optimal values)
- [x] `to_conic()` with SDP programs produces matching convex/conic values on dev CVXPY

🤖 Generated with [Claude Code](https://claude.com/claude-code)